### PR TITLE
Changed Modal component for upload library into a page and moved the …

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,11 +3,14 @@ import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbP
 import { Separator } from "@/components/ui/separator"
 import { SidebarInset, SidebarProvider, SidebarTrigger, } from "@/components/ui/sidebar"
 import { FlowDesigner } from "./components/flow/flow"
+import { RAGManagement } from "./pages/knowledge"
+import { useState } from "react"
 
 export function App() {
+  const [showLibrary, setShowLibrary] = useState(false)
 
   return <SidebarProvider>
-    <AppSidebar />
+    <AppSidebar onLibraryOpen={() => setShowLibrary(true)} />
     <SidebarInset>
       <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12">
         <div className="flex items-center gap-2 px-4">
@@ -20,18 +23,21 @@ export function App() {
               </BreadcrumbItem>
               <BreadcrumbSeparator className="hidden md:block" />
               <BreadcrumbItem>
-                <BreadcrumbPage>RAG Bot</BreadcrumbPage>
+                <BreadcrumbPage>{showLibrary ? "Library" : "RAG Bot"}</BreadcrumbPage>
               </BreadcrumbItem>
             </BreadcrumbList>
           </Breadcrumb>
         </div>
       </header>
       <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-        <FlowDesigner />
+        {showLibrary ? (
+          <RAGManagement onClose={() => setShowLibrary(false)} />
+        ) : (
+          <FlowDesigner />
+        )}
       </div>
     </SidebarInset>
   </SidebarProvider>
-
 }
 
 

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,19 +1,11 @@
 import { NavMain } from "@/components/nav-main"
 import { NavProjects } from "@/components/nav-projects"
 import { NavUser } from "@/components/nav-user"
-import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem, SidebarRail, useSidebar, } from "@/components/ui/sidebar"
-import { BookOpen, Bot, Frame, GalleryVerticalEnd, Map, PieChart, Settings2, SquareTerminal } from "lucide-react"
+import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem, SidebarRail } from "@/components/ui/sidebar"
+import { Bot, Frame, GalleryVerticalEnd, Map, PieChart, Settings2, SquareTerminal } from "lucide-react"
 import { useState } from "react"
-import { LiveDataModal } from "./forms/live-data-modal"
-import { RAGManagementModal } from "./forms/rag-management-modal"
-import { FilesModal } from "./forms/files-modal"
 
-export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
-  const [liveDataOpen, setLiveDataOpen] = useState(false)
-  const [dataManagementOpen, setDataManagementOpen] = useState(false)
-  const [ragManagementOpen, setRAGManagementOpen] = useState(false)
-  const [filesOpen, setFilesOpen] = useState(false)
-
+export function AppSidebar({ onLibraryOpen, ...props }: React.ComponentProps<typeof Sidebar> & { onLibraryOpen: () => void }) {
   // This is sample data.
   const data = {
     user: {
@@ -60,23 +52,8 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         title: "Knowledge",
         url: "#",
         icon: Frame,
-        items: [
-          { 
-            title: "Upload Files", 
-            url: "#",
-            onClick: () => setFilesOpen(true)
-          },
-          { 
-            title: "Connect Live Data", 
-            url: "#",
-            onClick: () => setLiveDataOpen(true)
-          },
-          { 
-            title: "Library", 
-            url: "#",
-            onClick: () => setRAGManagementOpen(true)
-          },
-        ],
+        onClick: () => onLibraryOpen(),
+        isLink: true,
       },
     ],
     projects: [
@@ -91,18 +68,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     if (section.title === "Knowledge") {
       return {
         ...section,
-        items: section.items.map(item => {
-          switch (item.title) {
-            case "Files":
-              return { ...item, onClick: () => setFilesOpen(true) }
-            case "Live Data":
-              return { ...item, onClick: () => setLiveDataOpen(true) }
-            case "Library":
-              return { ...item, onClick: () => setRAGManagementOpen(true) }
-            default:
-              return item
-          }
-        })
+        onClick: () => onLibraryOpen()
       }
     }
     return section
@@ -135,19 +101,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         </SidebarFooter>
         <SidebarRail />
       </Sidebar>
-
-      <FilesModal 
-        open={filesOpen}
-        onOpenChange={setFilesOpen}
-      />
-      <LiveDataModal 
-        open={liveDataOpen}
-        onOpenChange={setLiveDataOpen}
-      />
-      <RAGManagementModal
-        open={ragManagementOpen}
-        onOpenChange={setRAGManagementOpen}
-      />
     </>
   )
 }

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -8,6 +8,8 @@ interface Props {
     url: string
     icon?: LucideIcon
     isActive?: boolean
+    isLink?: boolean
+    onClick?: () => void
     items?: {
       title: string
       url: string
@@ -17,43 +19,56 @@ interface Props {
 }
 
 export function NavMain({ items }: Props) {
-
   return <SidebarGroup>
     <SidebarGroupLabel>Platform</SidebarGroupLabel>
     <SidebarMenu>
-      {items.map((item) => (
-        <Collapsible key={item.title} asChild defaultOpen={item.isActive} className="group/collapsible">
-          <SidebarMenuItem>
-            <CollapsibleTrigger asChild>
-              <SidebarMenuButton tooltip={item.title}>
+      {items.map((item) => {
+        // If the item is a direct link (has onClick and isLink), render it without Collapsible
+        if (item.onClick && item.isLink) {
+          return (
+            <SidebarMenuItem key={item.title}>
+              <SidebarMenuButton tooltip={item.title} onClick={item.onClick}>
                 {item.icon && <item.icon />}
                 <span>{item.title}</span>
-                <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
               </SidebarMenuButton>
-            </CollapsibleTrigger>
-            <CollapsibleContent>
-              <SidebarMenuSub>
-                {item.items?.map((subItem) => (
-                  <SidebarMenuSubItem key={subItem.title}>
-                    {subItem.onClick ? (
-                      <SidebarMenuSubButton onClick={subItem.onClick}>
-                        <span>{subItem.title}</span>
-                      </SidebarMenuSubButton>
-                    ) : (
-                      <SidebarMenuSubButton asChild>
-                        <a href={subItem.url}>
+            </SidebarMenuItem>
+          )
+        }
+
+        // Otherwise, render the collapsible menu item
+        return (
+          <Collapsible key={item.title} asChild defaultOpen={item.isActive} className="group/collapsible">
+            <SidebarMenuItem>
+              <CollapsibleTrigger asChild>
+                <SidebarMenuButton tooltip={item.title}>
+                  {item.icon && <item.icon />}
+                  <span>{item.title}</span>
+                  <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
+                </SidebarMenuButton>
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <SidebarMenuSub>
+                  {item.items?.map((subItem) => (
+                    <SidebarMenuSubItem key={subItem.title}>
+                      {subItem.onClick ? (
+                        <SidebarMenuSubButton onClick={subItem.onClick}>
                           <span>{subItem.title}</span>
-                        </a>
-                      </SidebarMenuSubButton>
-                    )}
-                  </SidebarMenuSubItem>
-                ))}
-              </SidebarMenuSub>
-            </CollapsibleContent>
-          </SidebarMenuItem>
-        </Collapsible>
-      ))}
+                        </SidebarMenuSubButton>
+                      ) : (
+                        <SidebarMenuSubButton asChild>
+                          <a href={subItem.url}>
+                            <span>{subItem.title}</span>
+                          </a>
+                        </SidebarMenuSubButton>
+                      )}
+                    </SidebarMenuSubItem>
+                  ))}
+                </SidebarMenuSub>
+              </CollapsibleContent>
+            </SidebarMenuItem>
+          </Collapsible>
+        )
+      })}
     </SidebarMenu>
   </SidebarGroup>
-
 }

--- a/src/pages/knowledge.tsx
+++ b/src/pages/knowledge.tsx
@@ -1,14 +1,13 @@
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import React from "react"
-import { FilesModal } from "./files-modal"
-import { LiveDataModal } from "./live-data-modal"
-import { availableSources, updateAvailableSources } from "./files-modal"
+import { FilesModal } from "../components/forms/files-modal"
+import { LiveDataModal } from "../components/forms/live-data-modal"
+import { availableSources, updateAvailableSources } from "../components/forms/files-modal"
 import { SourcesTable } from "@/components/sources-table"
 
-interface RAGManagementModalProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
+interface RAGManagementProps {
+  onClose?: () => void
 }
 
 // This would come from your backend in reality
@@ -110,7 +109,7 @@ type SortConfig = {
   direction: 'asc' | 'desc'
 }
 
-export function RAGManagementModal({ open, onOpenChange }: RAGManagementModalProps) {
+export function RAGManagement({ onClose }: RAGManagementProps) {
   const [sources, setSources] = React.useState(availableSources)
   const [selectedSources, setSelectedSources] = React.useState<string[]>([])
   const [previewContent, setPreviewContent] = React.useState<{ name: string; content: string } | null>(null)
@@ -125,7 +124,7 @@ export function RAGManagementModal({ open, onOpenChange }: RAGManagementModalPro
       tags: source.tags || [] // Ensure tags is at least an empty array
     }))
     setSources(sourcesWithTags)
-  }, [open, filesModalOpen])
+  }, [filesModalOpen])
 
   const handleDelete = (id: string) => {
     // Update both local state and availableSources
@@ -157,16 +156,18 @@ export function RAGManagementModal({ open, onOpenChange }: RAGManagementModalPro
   }
 
   return (
-    <>
-      <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="sm:max-w-[900px]">
-          <DialogHeader>
-            <DialogTitle>Library</DialogTitle>
-            <DialogDescription>
+    <div className="flex flex-col h-full">
+      <div className="flex-1 space-y-4 p-8 pt-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-3xl font-bold tracking-tight">Library</h2>
+            <p className="text-muted-foreground">
               Available data sources in your knowledge library.
-            </DialogDescription>
-          </DialogHeader>
-          
+            </p>
+          </div>
+        </div>
+        
+        <div className="space-y-4">
           <SourcesTable 
             sources={sources}
             selectedSources={selectedSources}
@@ -188,29 +189,29 @@ export function RAGManagementModal({ open, onOpenChange }: RAGManagementModalPro
             showAddButton={true}
           />
 
-          <DialogFooter className="mt-4">
-            <div className="flex justify-between w-full">
-              <div className="text-sm text-gray-500">
-                {selectedSources.length} sources selected
-              </div>
-              <div className="space-x-2">
-                <Button variant="outline" onClick={() => onOpenChange(false)}>Close</Button>
-                <Button 
-                  variant="default" 
-                  disabled={selectedSources.length === 0}
-                  onClick={() => {
-                    // Handle save selected sources
-                    console.log('Selected sources:', selectedSources)
-                    onOpenChange(false)
-                  }}
-                >
-                  Save Selection
-                </Button>
-              </div>
+          <div className="flex justify-between items-center">
+            <div className="text-sm text-muted-foreground">
+              {selectedSources.length} sources selected
             </div>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+            <div className="space-x-2">
+              {onClose && (
+                <Button variant="outline" onClick={onClose}>Close</Button>
+              )}
+              <Button 
+                variant="default" 
+                disabled={selectedSources.length === 0}
+                onClick={() => {
+                  // Handle save selected sources
+                  console.log('Selected sources:', selectedSources)
+                  onClose?.()
+                }}
+              >
+                Save Selection
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
 
       {/* Content Preview Dialog */}
       <Dialog open={!!previewContent} onOpenChange={() => setPreviewContent(null)}>
@@ -240,6 +241,6 @@ export function RAGManagementModal({ open, onOpenChange }: RAGManagementModalPro
         open={liveDataModalOpen}
         onOpenChange={setLiveDataModalOpen}
       />
-    </>
+    </div>
   )
 } 


### PR DESCRIPTION
The previous modal for managing the upload library (formerly RAGManagementModal) has been refactored into a full-page component (RAGManagement in src/pages/knowledge.tsx).

In App.tsx, a state flag (showLibrary) now toggles between displaying the main FlowDesigner and the Library page. The breadcrumb label updates accordingly to indicate whether the user is in the "RAG Bot" or "Library" view. This will probably change once we get the app router up and running.

The AppSidebar component has been updated to pass an onLibraryOpen callback. The Knowledge section now triggers navigation to the dedicated Library page instead of opening individual modals for file uploads, live data, or library management.

Minor adjustments in the navigation (NavMain) to make it so that it opens to this page