### PR TITLE
feat: add settings pages with teams and projects management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,11 @@ import { CollectionsManagement } from "./pages/knowledge"
 import { BotLogsTable } from "./pages/logs"
 import { BotManagement } from "./pages/bots"
 import { SourcesManagement } from "./pages/sources"
+import { SettingsLayout } from "./pages/settings/layout"
+import { ProjectsSettings } from "./pages/settings/projects"
+import { TeamSettings } from "./pages/settings/team"
+import { UsageSettings } from "./pages/settings/usage"
+import { BillingSettings } from "./pages/settings/billing"
 
 const routeNames: Record<string, string> = {
   '/': 'Designer',
@@ -16,7 +21,11 @@ const routeNames: Record<string, string> = {
   '/rag': 'Collections',
   '/sources': 'Data Sources',
   '/logs': 'Bot Logs',
-  '/bots': 'Bots'
+  '/bots': 'Bots',
+  '/settings/projects': 'Settings / Projects',
+  '/settings/team': 'Settings / Team',
+  '/settings/billing': 'Settings / Billing',
+  '/settings/usage': 'Settings / Usage'
 }
 
 function NavigationLink({ to, children }: { to: string; children: React.ReactNode }) {
@@ -66,6 +75,12 @@ function AppContent() {
             <Route path="/sources" element={<SourcesManagement />} />
             <Route path="/logs" element={<BotLogsTable />} />
             <Route path="/bots" element={<BotManagement />} />
+            <Route path="/settings" element={<SettingsLayout />}>
+              <Route path="projects" element={<ProjectsSettings />} />
+              <Route path="team" element={<TeamSettings />} />
+              <Route path="billing" element={<BillingSettings />} />
+              <Route path="usage" element={<UsageSettings />} />
+            </Route>
           </Routes>
         </div>
       </SidebarInset>

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -32,15 +32,13 @@ export function AppSidebar() {
       },
       {
         title: "Settings",
-        url: "#",
+        url: "settings",
         icon: Settings2,
         items: [
-          {
-            title: "General", url: "/",
-          },
-          { title: "Team", url: "/", },
-          { title: "Billing", url: "/", },
-          { title: "Limits", url: "/", },
+          { title: "Projects", url: "/settings/projects" },
+          { title: "Team", url: "/settings/team" },
+          { title: "Billing", url: "/settings/billing" },
+          { title: "Usage", url: "/settings/usage" },
         ],
       },
       {

--- a/src/pages/settings/billing.tsx
+++ b/src/pages/settings/billing.tsx
@@ -1,0 +1,81 @@
+import { Button } from "@/components/ui/button"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+
+export function BillingSettings() {
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <div>
+          <h3 className="text-lg font-medium">Billing & Subscription</h3>
+          <p className="text-sm text-muted-foreground">
+            Manage your billing information and subscription plan
+          </p>
+        </div>
+        <Button>Update Payment Method</Button>
+      </div>
+
+      <div className="grid gap-6">
+        <div className="rounded-lg border p-4">
+          <h4 className="text-sm font-medium mb-4">Current Plan</h4>
+          <div className="flex justify-between items-center">
+            <div>
+              <p className="font-medium">Enterprise Plan</p>
+              <p className="text-sm text-muted-foreground">$499/month</p>
+            </div>
+            <Button variant="outline">Change Plan</Button>
+          </div>
+        </div>
+
+        <div>
+          <h4 className="text-sm font-medium mb-4">Billing History</h4>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Date</TableHead>
+                <TableHead>Description</TableHead>
+                <TableHead>Amount</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Invoice</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <TableRow>
+                <TableCell>Mar 1, 2024</TableCell>
+                <TableCell>Enterprise Plan - Monthly</TableCell>
+                <TableCell>$499.00</TableCell>
+                <TableCell>
+                  <span className="text-green-600">Paid</span>
+                </TableCell>
+                <TableCell className="text-right">
+                  <Button variant="ghost" size="sm">Download</Button>
+                </TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Feb 1, 2024</TableCell>
+                <TableCell>Enterprise Plan - Monthly</TableCell>
+                <TableCell>$499.00</TableCell>
+                <TableCell>
+                  <span className="text-green-600">Paid</span>
+                </TableCell>
+                <TableCell className="text-right">
+                  <Button variant="ghost" size="sm">Download</Button>
+                </TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Jan 1, 2024</TableCell>
+                <TableCell>Enterprise Plan - Monthly</TableCell>
+                <TableCell>$499.00</TableCell>
+                <TableCell>
+                  <span className="text-green-600">Paid</span>
+                </TableCell>
+                <TableCell className="text-right">
+                  <Button variant="ghost" size="sm">Download</Button>
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </div>
+  )
+} 

--- a/src/pages/settings/layout.tsx
+++ b/src/pages/settings/layout.tsx
@@ -1,0 +1,38 @@
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { useNavigate, useLocation } from "react-router-dom"
+import { Outlet } from "react-router-dom"
+
+export function SettingsLayout() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const currentPath = location.pathname.split("/").pop()
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="border-b">
+        <div className="px-8 py-6">
+          <h2 className="text-3xl font-bold tracking-tight">Settings</h2>
+        </div>
+        <Tabs value={currentPath} className="px-8">
+          <TabsList>
+            <TabsTrigger value="projects" onClick={() => navigate("/settings/projects")}>
+              Projects
+            </TabsTrigger>
+            <TabsTrigger value="team" onClick={() => navigate("/settings/team")}>
+              Team
+            </TabsTrigger>
+            <TabsTrigger value="billing" onClick={() => navigate("/settings/billing")}>
+              Billing
+            </TabsTrigger>
+            <TabsTrigger value="usage" onClick={() => navigate("/settings/usage")}>
+              Usage
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </div>
+      <div className="flex-1 p-8">
+        <Outlet />
+      </div>
+    </div>
+  )
+} 

--- a/src/pages/settings/projects.tsx
+++ b/src/pages/settings/projects.tsx
@@ -1,0 +1,138 @@
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { useState } from "react"
+
+interface Project {
+  id: string
+  name: string
+  createdAt: string
+  teamId: string
+  status: "active" | "archived"
+}
+
+interface Team {
+  id: string
+  name: string
+  members: number
+}
+
+export function ProjectsSettings() {
+  const [teams] = useState<Team[]>([
+    { id: "1", name: "Emergency Response Team", members: 5 },
+    { id: "2", name: "Refugee Support Team", members: 3 },
+    { id: "3", name: "Medical Aid Team", members: 4 }
+  ])
+
+  const [projects, setProjects] = useState<Project[]>([
+    {
+      id: "1",
+      name: "Syria Crisis Response",
+      createdAt: "2024-01-01",
+      teamId: "1",
+      status: "active"
+    },
+    {
+      id: "2",
+      name: "Mediterranean Rescue Operations",
+      createdAt: "2024-02-15",
+      teamId: "2",
+      status: "active"
+    },
+    {
+      id: "3",
+      name: "Gaza Medical Support",
+      createdAt: "2024-03-01",
+      teamId: "3",
+      status: "active"
+    },
+    {
+      id: "4",
+      name: "Ukraine Aid Coordination",
+      createdAt: "2024-02-01",
+      teamId: "1",
+      status: "active"
+    }
+  ])
+
+  const getTeamName = (teamId: string) => {
+    return teams.find(team => team.id === teamId)?.name || 'Unassigned'
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <div>
+          <h3 className="text-lg font-medium">Projects</h3>
+          <p className="text-sm text-muted-foreground">
+            Manage your organization's projects and team assignments
+          </p>
+        </div>
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button>Create Project</Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Create New Project</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4 py-4">
+              <div className="space-y-2">
+                <label htmlFor="name">Project Name</label>
+                <Input id="name" placeholder="Enter project name" />
+              </div>
+              <div className="space-y-2">
+                <label>Assigned Team</label>
+                <Select>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select a team" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {teams.map(team => (
+                      <SelectItem key={team.id} value={team.id}>
+                        {team.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <Button>Create Project</Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Team</TableHead>
+            <TableHead>Created</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead className="text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {projects.map((project) => (
+            <TableRow key={project.id}>
+              <TableCell>{project.name}</TableCell>
+              <TableCell>{getTeamName(project.teamId)}</TableCell>
+              <TableCell>{new Date(project.createdAt).toLocaleDateString()}</TableCell>
+              <TableCell>
+                <span className={`capitalize ${project.status === 'active' ? 'text-green-600' : 'text-gray-500'}`}>
+                  {project.status}
+                </span>
+              </TableCell>
+              <TableCell className="text-right">
+                <Button variant="ghost" size="sm">Edit</Button>
+                <Button variant="ghost" size="sm" className="text-red-600">Archive</Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+} 

--- a/src/pages/settings/team.tsx
+++ b/src/pages/settings/team.tsx
@@ -1,0 +1,137 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+
+interface Team {
+  id: string
+  name: string
+  description: string
+  members: TeamMember[]
+  createdAt: string
+}
+
+interface TeamMember {
+  id: string
+  name: string
+  email: string
+  role: "owner" | "admin" | "member"
+  joined: string
+}
+
+export function TeamSettings() {
+  const teams: Team[] = [
+    {
+      id: "1",
+      name: "Emergency Response Team",
+      description: "Coordinating rapid response to humanitarian crises",
+      createdAt: "2024-01-01",
+      members: [
+        {
+          id: "1",
+          name: "John Doe",
+          email: "john@example.com",
+          role: "owner",
+          joined: "2024-01-01"
+        },
+        {
+          id: "2",
+          name: "Jane Smith",
+          email: "jane@example.com",
+          role: "admin",
+          joined: "2024-01-15"
+        }
+      ]
+    },
+    {
+      id: "2",
+      name: "Refugee Support Team",
+      description: "Supporting displaced populations and asylum seekers",
+      createdAt: "2024-02-01",
+      members: [
+        {
+          id: "3",
+          name: "Alice Johnson",
+          email: "alice@example.com",
+          role: "admin",
+          joined: "2024-02-01"
+        }
+      ]
+    },
+    {
+      id: "3",
+      name: "Medical Aid Team",
+      description: "Coordinating medical assistance and healthcare support",
+      createdAt: "2024-02-15",
+      members: [
+        {
+          id: "4",
+          name: "David Wilson",
+          email: "david@example.com",
+          role: "admin",
+          joined: "2024-02-15"
+        }
+      ]
+    }
+  ]
+
+  return (
+    <div className="space-y-8">
+      <div className="flex justify-between items-center">
+        <div>
+          <h3 className="text-lg font-medium">Teams</h3>
+          <p className="text-sm text-muted-foreground">
+            Manage your organization's teams and their members
+          </p>
+        </div>
+        <Button>Create Team</Button>
+      </div>
+
+      {teams.map((team) => (
+        <div key={team.id} className="space-y-4">
+          <div className="flex justify-between items-center">
+            <div>
+              <h4 className="text-md font-medium">{team.name}</h4>
+              <p className="text-sm text-muted-foreground">{team.description}</p>
+            </div>
+            <Button variant="outline">Add Member</Button>
+          </div>
+
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Member</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead>Joined</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {team.members.map((member) => (
+                <TableRow key={member.id}>
+                  <TableCell className="flex items-center gap-2">
+                    <Avatar className="h-8 w-8">
+                      <AvatarImage src={`https://avatar.vercel.sh/${member.email}`} />
+                      <AvatarFallback>{member.name[0]}</AvatarFallback>
+                    </Avatar>
+                    <div>
+                      <div className="font-medium">{member.name}</div>
+                      <div className="text-sm text-muted-foreground">{member.email}</div>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <span className="capitalize">{member.role}</span>
+                  </TableCell>
+                  <TableCell>{new Date(member.joined).toLocaleDateString()}</TableCell>
+                  <TableCell className="text-right">
+                    <Button variant="ghost" size="sm">Edit Role</Button>
+                    <Button variant="ghost" size="sm" className="text-red-600">Remove</Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      ))}
+    </div>
+  )
+} 

--- a/src/pages/settings/usage.tsx
+++ b/src/pages/settings/usage.tsx
@@ -1,0 +1,87 @@
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+
+export function UsageSettings() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-medium">Usage</h3>
+        <p className="text-sm text-muted-foreground">
+          Monitor your organization's AI usage and limits
+        </p>
+      </div>
+
+      <div className="grid gap-4">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Metric</TableHead>
+              <TableHead>Usage</TableHead>
+              <TableHead>Limit</TableHead>
+              <TableHead>Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow>
+              <TableCell className="font-medium">Total Tokens</TableCell>
+              <TableCell>1.2M</TableCell>
+              <TableCell>2M</TableCell>
+              <TableCell>
+                <span className="text-green-600">60% used</span>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell className="font-medium">API Calls</TableCell>
+              <TableCell>8,432</TableCell>
+              <TableCell>20,000</TableCell>
+              <TableCell>
+                <span className="text-green-600">40% used</span>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell className="font-medium">Storage</TableCell>
+              <TableCell>2.1 GB</TableCell>
+              <TableCell>10 GB</TableCell>
+              <TableCell>
+                <span className="text-green-600">21% used</span>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+
+        <div className="mt-8">
+          <h4 className="text-sm font-medium mb-4">Usage History</h4>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Date</TableHead>
+                <TableHead>Tokens Used</TableHead>
+                <TableHead>API Calls</TableHead>
+                <TableHead>Storage Change</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <TableRow>
+                <TableCell>Mar 15, 2024</TableCell>
+                <TableCell>125K</TableCell>
+                <TableCell>842</TableCell>
+                <TableCell>+120MB</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Mar 14, 2024</TableCell>
+                <TableCell>98K</TableCell>
+                <TableCell>731</TableCell>
+                <TableCell>+85MB</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Mar 13, 2024</TableCell>
+                <TableCell>156K</TableCell>
+                <TableCell>912</TableCell>
+                <TableCell>+250MB</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </div>
+  )
+} 


### PR DESCRIPTION
Settings Pages Addition

- Added settings layout with tabs for navigation and settings pages
- Implemented projects page for managing team assignments and project status
- Created team management interface for handling members and roles
- Added billing and usage pages for subscription/resource tracking

*NOTE: These are all just placeholder tables. These tables are full of sample slop and need to be refactored to pull data from the Supabase schemas once these are set up.