### PR TITLE
Adding vector search through Supabase sources

### DIFF
--- a/src/lib/agents/workers/search.ts
+++ b/src/lib/agents/workers/search.ts
@@ -13,16 +13,16 @@ declare global {
       domain: NodeIO
       distance: NodeIO
       maxResults: NodeIO
-      collection: NodeIO
+      collections: NodeIO
 
       condition: NodeIO
     },
     parameters: {
-      engine?: "weaviate" | "exa"
+      engine?: "weaviate" | "exa" | "supabase"
       maxResults?: number
       domain?: string
       distance?: number
-      collection?: string
+      collections?: string[]
     }
   }
 
@@ -60,115 +60,129 @@ function deduplicateDocuments(array: VectorDocument[]): VectorDocument[] {
 }
 
 async function execute(worker: SearchWorker) {
+  console.log("Executing search worker with parameters:", worker.parameters);
 
-  console.log("Executing search worker with parameters:", worker.parameters)
+  worker.fields.output.value = [];
+  worker.fields.references.value = [];
 
-  worker.fields.output.value = []
-  worker.fields.references.value = []
-
-  const query = worker.fields.input.value || ""
+  const query = worker.fields.input.value || "";
   if (!query) {
-    console.log("Search worker: No query provided.")
-    return
+    console.log("Search worker: No query provided.");
+    return;
   }
 
-  const domains = worker.parameters.domain ? [worker.parameters.domain] : []
-  const limit = worker.parameters.maxResults || 5
-  const similarityThreshold = worker.parameters.distance ?? 0.3
-  const collectionId = worker.parameters.collection
+  const engine = worker.parameters.engine || "weaviate"; // Default to an external engine
+  let finalResults: VectorDocument[] = [];
+  let deduped: VectorDocument[] = [];
 
-  const externalSearchDistance = 0.5;
+  // --- Engine-Specific Search Logic --- 
 
-  let combinedResults: VectorDocument[] = []
+  if (engine === 'supabase') {
+    // --- Supabase Search Path --- 
+    const collectionIds = worker.parameters.collections; // Array of IDs
+    const limit = worker.parameters.maxResults || 5;
+    const similarityThreshold = worker.parameters.distance ?? 0.3;
 
-  // 1. Perform external search (e.g., Directus)
-  try {
-    const externalSearchUrl = "https://directus-qa-support.azurewebsites.net/search"
-    console.log(`Performing external search to ${externalSearchUrl} with query: "${query}", domains: ${domains}, limit: ${limit}, distance: ${externalSearchDistance}`)
-    const r = await axios.post(externalSearchUrl, {
-      query,
-      domains,
-      limit,
-      distance: externalSearchDistance,
-    })
-    const externalData = r.data as VectorDocument[] || []
-    console.log("External search results:", externalData.length)
-    combinedResults = combinedResults.concat(externalData)
-  } catch (error) {
-    console.error("Error during external search:", error)
-    // Decide if you want to stop or continue if external search fails
-  }
+    if (collectionIds && collectionIds.length > 0) {
+      console.log(`[Supabase Path] Searching ${collectionIds.length} collections:`, collectionIds);
+      let queryEmbedding: number[] | null = null;
+      try {
+        // Generate embedding once
+        const { data: embedding, error: embeddingError } = await generateEmbedding(query);
+        if (embeddingError || !embedding) throw embeddingError || new Error("Failed to generate query embedding.");
+        queryEmbedding = embedding;
+        console.log(`[Supabase Path] Generated query embedding (length: ${queryEmbedding.length}).`);
 
-  // 2. Perform Supabase vector search if collection is specified
-  if (collectionId) {
-    console.log(`Performing Supabase vector search in collection: ${collectionId} (Limit: ${limit}, Threshold: ${similarityThreshold})`)
-    try {
-      // Generate embedding for the query
-      const { data: queryEmbedding, error: embeddingError } = await generateEmbedding(query)
-
-      if (embeddingError || !queryEmbedding) {
-        throw embeddingError || new Error("Failed to generate query embedding.")
-      }
-
-      console.log(`Generated query embedding (length: ${queryEmbedding.length}). Calling Supabase RPC 'similarity_search'...`)
-
-      // Call the updated RPC function 'similarity_search' with all parameters
-      const { data: supabaseMatches, error: rpcError } = await supabase.rpc('similarity_search', {
-        query_vector: queryEmbedding,
-        target_collection_id: collectionId,
-        match_threshold: similarityThreshold,
-        match_count: limit
-      })
-
-      if (rpcError) {
-        throw rpcError
-      }
-
-      console.log("Supabase vector search raw results:", supabaseMatches)
-
-      // Transform Supabase results based on 'similarity_search' function output
-      // Assuming the RPC function now returns: { id, name, content, similarity, source_type }
-      const supabaseVectorDocs: VectorDocument[] = (supabaseMatches || []).map((match: any) => {
-        // Construct the title using the name (fallback to type/ID) and add similarity
-        const title = `${match.name || `[DB] ${match.source_type}:${match.id.substring(0, 8)}`} (Sim: ${match.similarity?.toFixed(3) ?? 'N/A'})`;
+        // Search all collections concurrently
+        const searchPromises = collectionIds.map(async (collectionId) => {
+            console.log(`  - Searching collection: ${collectionId} (Limit: ${limit}, Threshold: ${similarityThreshold})`);
+            try {
+                const { data: supabaseMatches, error: rpcError } = await supabase.rpc('similarity_search', {
+                    query_vector: queryEmbedding,
+                    target_collection_id: collectionId,
+                    match_threshold: similarityThreshold,
+                    match_count: limit
+                });
+                if (rpcError) throw rpcError; // Propagate error to Promise.all catch
+                
+                // Transform results
+                return (supabaseMatches || []).map((match: any) => {
+                    const title = `${match.name || `[DB] ${match.source_type}:${match.id.substring(0, 8)}`} (Sim: ${match.similarity?.toFixed(3) ?? 'N/A'})`;
+                    return {
+                        ref: `supabase:${match.source_type}:${match.id}`,
+                        title: title,
+                        body: match.content,
+                        source: `supabase_collection:${collectionId}`,
+                    };
+                });
+            } catch (error) {
+                console.error(`  - Error searching collection ${collectionId}:`, error);
+                return []; // Return empty for this collection on error
+            }
+        });
         
-        return {
-          ref: `supabase:${match.source_type}:${match.id}`, // Construct ref using type and id
-          title: title, // Assign the constructed title
-          body: match.content, // Use content as body
-          source: `supabase_collection:${collectionId}`, // Indicate it's from the specified Supabase collection
-        };
-      });
+        // Aggregate results
+        const resultsFromAllCollections = await Promise.all(searchPromises);
+        finalResults = resultsFromAllCollections.flat(); // Assign directly to finalResults
+        console.log(`[Supabase Path] Total results: ${finalResults.length}`);
 
-      console.log("Transformed Supabase results:", supabaseVectorDocs.length)
-      combinedResults = combinedResults.concat(supabaseVectorDocs)
+      } catch (error) {
+        console.error("[Supabase Path] Error during search process:", error);
+        finalResults = []; // Ensure empty results on error
+      }
+    } else {
+        console.log("[Supabase Path] No collection IDs provided.");
+        finalResults = [];
+    }
 
-    } catch (error) {
-      console.error("Error during Supabase vector search:", error)
-      // Decide if you want to stop or continue if Supabase search fails
+  } else {
+    // --- External Engine Search Path (Weaviate, Exa, etc.) --- 
+    const domain = worker.parameters.domain;
+    const limit = worker.parameters.maxResults || 5;
+    const externalSearchDistance = worker.parameters.distance ?? 0.5; // Use distance, default 0.5
+
+    if (domain) {
+      console.log(`[External Path] Searching engine '${engine}' in domain: ${domain} (Limit: ${limit}, Distance: ${externalSearchDistance})`);
+      try {
+        const externalSearchUrl = "https://directus-qa-support.azurewebsites.net/search"; // Assuming this URL handles different engines or we need logic here
+        const r = await axios.post(externalSearchUrl, {
+          query,
+          domains: [domain], // Pass domain in array
+          limit,
+          distance: externalSearchDistance,
+          // We might need to pass the 'engine' type to the backend if it handles multiple engines
+          // engine: engine, 
+        });
+        finalResults = r.data as VectorDocument[] || []; // Assign directly
+        console.log(`[External Path] Total results: ${finalResults.length}`);
+      } catch (error) {
+        console.error("[External Path] Error during search:", error);
+        finalResults = []; // Ensure empty results on error
+      }
+    } else {
+        console.log("[External Path] No domain provided.");
+        finalResults = [];
     }
   }
 
-  // 3. Combine, deduplicate, and set output
-  console.log("Total combined results before deduplication:", combinedResults.length)
-  const deduped = deduplicateDocuments(combinedResults)
-  console.log("Deduplicated results:", deduped.length)
+  // --- Post-Search Processing (Deduplication) --- 
+  console.log("Total results before deduplication:", finalResults.length);
+  deduped = deduplicateDocuments(finalResults);
+  console.log("Deduplicated results:", deduped.length);
 
   if (deduped.length === 0) {
-    console.log("Search worker: No results found after combining and deduplicating.")
-    return
+    console.log("Search worker: No results found after search and deduplication.");
+    return;
   }
 
-  // Sort by relevance if possible (might need match_score from results)
-  // For now, just assign
-  worker.fields.output.value = deduped
-
+  // --- Set Output --- 
+  worker.fields.output.value = deduped;
   worker.fields.references.value = deduped.map(d => ({
-    link: d.ref || d.source || "", // Ensure link is populated
-    title: d.title || "Search Result" // Ensure title is populated
-  }))
+    link: d.ref || d.source || "",
+    title: d.title || "Search Result"
+  }));
 
-  console.log("Search worker execution finished.")
+  console.log("Search worker execution finished.");
 }
 
 
@@ -193,7 +207,7 @@ export const search: WorkerRegistryItem = {
         { type: "string", direction: "input", title: "Domain", name: "domain" },
         { type: "number", direction: "input", title: "Distance", name: "distance" },
         { type: "number", direction: "input", title: "Max Results", name: "maxResults" },
-        { type: "string", direction: "input", title: "Collection", name: "collection" },
+        { type: "string", direction: "input", title: "Collections", name: "collections" },
 
         { type: "unknown", direction: "input", title: "Condition", name: "condition", condition: true },
       ],

--- a/src/lib/agents/workers/search.ts
+++ b/src/lib/agents/workers/search.ts
@@ -1,4 +1,5 @@
 import axios from "axios"
+import { generateEmbedding, supabase } from "@/lib/data/supabaseFunctions"
 
 declare global {
 
@@ -12,6 +13,7 @@ declare global {
       domain: NodeIO
       distance: NodeIO
       maxResults: NodeIO
+      collection: NodeIO
 
       condition: NodeIO
     },
@@ -20,6 +22,7 @@ declare global {
       maxResults?: number
       domain?: string
       distance?: number
+      collection?: string
     }
   }
 
@@ -47,9 +50,10 @@ function deduplicateDocuments(array: VectorDocument[]): VectorDocument[] {
   const seen = {}
   const deduped: VectorDocument[] = []
   for (const d of array) {
-    if (!seen[d.source]) {
+    const key = `${d.source || 'unknown'}-${d.ref || d.title}`;
+    if (!seen[key]) {
       deduped.push(d)
-      seen[d.source] = true
+      seen[key] = true
     }
   }
   return deduped
@@ -57,33 +61,114 @@ function deduplicateDocuments(array: VectorDocument[]): VectorDocument[] {
 
 async function execute(worker: SearchWorker) {
 
-  console.log("Executing search worker...")
+  console.log("Executing search worker with parameters:", worker.parameters)
 
   worker.fields.output.value = []
   worker.fields.references.value = []
 
   const query = worker.fields.input.value || ""
+  if (!query) {
+    console.log("Search worker: No query provided.")
+    return
+  }
+
   const domains = worker.parameters.domain ? [worker.parameters.domain] : []
   const limit = worker.parameters.maxResults || 5
+  const similarityThreshold = worker.parameters.distance ?? 0.3
+  const collectionId = worker.parameters.collection
 
-  const r = await axios.post("https://directus-qa-support.azurewebsites.net/search", {
-    query,
-    domains,
-    limit,
-    distance: worker.parameters.distance || 0.2,
-  })
+  const externalSearchDistance = 0.5;
 
-  const data = r.data as VectorDocument[] || []
+  let combinedResults: VectorDocument[] = []
 
-  console.log("Search result: ", data)
+  // 1. Perform external search (e.g., Directus)
+  try {
+    const externalSearchUrl = "https://directus-qa-support.azurewebsites.net/search"
+    console.log(`Performing external search to ${externalSearchUrl} with query: "${query}", domains: ${domains}, limit: ${limit}, distance: ${externalSearchDistance}`)
+    const r = await axios.post(externalSearchUrl, {
+      query,
+      domains,
+      limit,
+      distance: externalSearchDistance,
+    })
+    const externalData = r.data as VectorDocument[] || []
+    console.log("External search results:", externalData.length)
+    combinedResults = combinedResults.concat(externalData)
+  } catch (error) {
+    console.error("Error during external search:", error)
+    // Decide if you want to stop or continue if external search fails
+  }
 
+  // 2. Perform Supabase vector search if collection is specified
+  if (collectionId) {
+    console.log(`Performing Supabase vector search in collection: ${collectionId} (Limit: ${limit}, Threshold: ${similarityThreshold})`)
+    try {
+      // Generate embedding for the query
+      const { data: queryEmbedding, error: embeddingError } = await generateEmbedding(query)
 
-  if (data.length === 0) return
-  worker.fields.output.value = data
+      if (embeddingError || !queryEmbedding) {
+        throw embeddingError || new Error("Failed to generate query embedding.")
+      }
 
-  const deduped = deduplicateDocuments(data)
-  worker.fields.references.value = deduped.map(d => ({ link: d.ref || "", title: d.title || "" }))
+      console.log(`Generated query embedding (length: ${queryEmbedding.length}). Calling Supabase RPC 'similarity_search'...`)
 
+      // Call the updated RPC function 'similarity_search' with all parameters
+      const { data: supabaseMatches, error: rpcError } = await supabase.rpc('similarity_search', {
+        query_vector: queryEmbedding,
+        target_collection_id: collectionId,
+        match_threshold: similarityThreshold,
+        match_count: limit
+      })
+
+      if (rpcError) {
+        throw rpcError
+      }
+
+      console.log("Supabase vector search raw results:", supabaseMatches)
+
+      // Transform Supabase results based on 'similarity_search' function output
+      // Assuming the RPC function now returns: { id, name, content, similarity, source_type }
+      const supabaseVectorDocs: VectorDocument[] = (supabaseMatches || []).map((match: any) => {
+        // Construct the title using the name (fallback to type/ID) and add similarity
+        const title = `${match.name || `[DB] ${match.source_type}:${match.id.substring(0, 8)}`} (Sim: ${match.similarity?.toFixed(3) ?? 'N/A'})`;
+        
+        return {
+          ref: `supabase:${match.source_type}:${match.id}`, // Construct ref using type and id
+          title: title, // Assign the constructed title
+          body: match.content, // Use content as body
+          source: `supabase_collection:${collectionId}`, // Indicate it's from the specified Supabase collection
+        };
+      });
+
+      console.log("Transformed Supabase results:", supabaseVectorDocs.length)
+      combinedResults = combinedResults.concat(supabaseVectorDocs)
+
+    } catch (error) {
+      console.error("Error during Supabase vector search:", error)
+      // Decide if you want to stop or continue if Supabase search fails
+    }
+  }
+
+  // 3. Combine, deduplicate, and set output
+  console.log("Total combined results before deduplication:", combinedResults.length)
+  const deduped = deduplicateDocuments(combinedResults)
+  console.log("Deduplicated results:", deduped.length)
+
+  if (deduped.length === 0) {
+    console.log("Search worker: No results found after combining and deduplicating.")
+    return
+  }
+
+  // Sort by relevance if possible (might need match_score from results)
+  // For now, just assign
+  worker.fields.output.value = deduped
+
+  worker.fields.references.value = deduped.map(d => ({
+    link: d.ref || d.source || "", // Ensure link is populated
+    title: d.title || "Search Result" // Ensure title is populated
+  }))
+
+  console.log("Search worker execution finished.")
 }
 
 
@@ -108,8 +193,7 @@ export const search: WorkerRegistryItem = {
         { type: "string", direction: "input", title: "Domain", name: "domain" },
         { type: "number", direction: "input", title: "Distance", name: "distance" },
         { type: "number", direction: "input", title: "Max Results", name: "maxResults" },
-
-
+        { type: "string", direction: "input", title: "Collection", name: "collection" },
 
         { type: "unknown", direction: "input", title: "Condition", name: "condition", condition: true },
       ],


### PR DESCRIPTION
This pull request is adding vector search functionality through Supabase sources to the existing search capabilities. The PR adds:

A new "Collection" field in the search node interface that allows users to select from available Supabase collections
Integration with Supabase's vector search capabilities alongside the existing external search functionality
Enhanced result handling that combines, deduplicates, and processes results from both search sources

The main changes are in three files:

src/components/flow/nodes/search.tsx: Added UI components for Supabase collection selection and improved state management
src/lib/agents/workers/search.ts: Added Supabase vector search functionality that generates embeddings for queries and uses Supabase's similarity search RPC
src/pages/sources.tsx: Various improvements to logging and state management... fixing a bug in the sources table