### PR TITLE
feat: integrate Toaster component into Page layout

### DIFF
--- a/src/components/datatable/datatable.tsx
+++ b/src/components/datatable/datatable.tsx
@@ -21,6 +21,7 @@ import { format } from 'date-fns'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "../ui/accordion"
 import { useNavigate } from "react-router-dom"
 import { ToolbarItem } from "./toolbaritem"
+import { DeclarativeMenu } from "../declarativemenu"
 
 
 declare global {
@@ -28,13 +29,12 @@ declare global {
   type Columns<T = any> = { [key in keyof T]?: Column<T, T[key]> }
   type PaginationData = PaginationState
 }
-export interface DataTableProps<T = any> extends Omit<React.HTMLAttributes<HTMLDivElement>, "onLoad"> {
-  data?: T[]
-  columns?: Columns<T>
+export interface DataTableProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "onLoad"> {
+  data?: any[]
+  columns?: Columns<any>
   hideSelection?: boolean
-  hideActions?: boolean
-  onRowClick?: ((row: T) => void) | string
-  onLoad?: (state: PaginationState) => Promise<T[]>
+  onRowClick?: ((row: any) => void) | string
+  onLoad?: (state: PaginationState) => Promise<any[]>
   onPaginationChange?: (state: PaginationState) => void
   showSearch?: boolean
   showColumnSelection?: boolean
@@ -43,14 +43,15 @@ export interface DataTableProps<T = any> extends Omit<React.HTMLAttributes<HTMLD
   loading?: boolean
   sort?: [string, "asc" | "desc"]
   onSortingChange?: (field: string, direction: "asc" | "desc" | undefined) => void
+  actions?: DropdownMenuContents
+  onActionExecuted?: () => Promise<void>
 }
 
 
-export function DataTable<T = any>(props: DataTableProps<T>) {
+export function DataTable(props: DataTableProps) {
 
   let {
     hideSelection,
-    hideActions,
     columns,
     onRowClick,
     loading,
@@ -58,7 +59,12 @@ export function DataTable<T = any>(props: DataTableProps<T>) {
     showColumnSelection = true,
     showPagination = true,
     sort,
+    actions,
+    onActionExecuted,
   } = props
+
+  let hideActions = !actions
+
 
   const sortingState: SortingState = sort ? [{ id: sort[0], desc: sort[1] == "desc" }] : []
 
@@ -153,6 +159,7 @@ export function DataTable<T = any>(props: DataTableProps<T>) {
   }
 
   const table = useReactTable(options)
+
   let Empty = <EmptyData />
   const selectionColumnWidth = !hideSelection ? 48 : 0 // 48px for w-12
   const actionsColumnWidth = !hideActions ? 48 : 0 // 48px for w-12
@@ -226,12 +233,22 @@ export function DataTable<T = any>(props: DataTableProps<T>) {
 
             {!hideActions && <TableCell className="p-0 pl-4 w-10 sticky right-0 bg-background z-10" onClick={(e) => e.stopPropagation()} >
               <div className="absolute top-0 right-0 bottom-0 w-full h-full border-l pl-3 pt-2">
+                <DeclarativeMenu menu={actions} reference={row.original} onActionExecuted={onActionExecuted} >
+                  <Button size="icon" variant="ghost" className="size-6">
+                    <MoreHorizontal size={16} />
+                  </Button>
+                </DeclarativeMenu>
+              </div>
+            </TableCell>}
+
+            {/* {!hideActions && <TableCell className="p-0 pl-4 w-10 sticky right-0 bg-background z-10" onClick={(e) => e.stopPropagation()} >
+              <div className="absolute top-0 right-0 bottom-0 w-full h-full border-l pl-3 pt-2">
                 <Button size="icon" variant="ghost" className="size-6">
                   <MoreHorizontal size={16} />
                 </Button>
               </div>
             </TableCell>}
-
+ */}
           </TableRow>
         ))}
       </TableBody>

--- a/src/components/datatable/supadatatable.tsx
+++ b/src/components/datatable/supadatatable.tsx
@@ -9,41 +9,59 @@ import { ToolbarItem } from "./toolbaritem"
 import { Clock } from "lucide-react"
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip"
 
-type TableKeys = keyof Database["public"]["Tables"]
-type SupabaseFilterBuilder<T extends TableKeys> = {
-  eq: (column: keyof Database["public"]["Tables"][T]["Row"], value: any) => SupabaseFilterBuilder<T>
-  neq: (column: keyof Database["public"]["Tables"][T]["Row"], value: any) => SupabaseFilterBuilder<T>
-  gt: (column: keyof Database["public"]["Tables"][T]["Row"], value: any) => SupabaseFilterBuilder<T>
-  gte: (column: keyof Database["public"]["Tables"][T]["Row"], value: any) => SupabaseFilterBuilder<T>
-  lt: (column: keyof Database["public"]["Tables"][T]["Row"], value: any) => SupabaseFilterBuilder<T>
-  lte: (column: keyof Database["public"]["Tables"][T]["Row"], value: any) => SupabaseFilterBuilder<T>
-  like: (column: keyof Database["public"]["Tables"][T]["Row"], pattern: string) => SupabaseFilterBuilder<T>
-  ilike: (column: keyof Database["public"]["Tables"][T]["Row"], pattern: string) => SupabaseFilterBuilder<T>
-  is: (column: keyof Database["public"]["Tables"][T]["Row"], value: null | boolean) => SupabaseFilterBuilder<T>
-  in: (column: keyof Database["public"]["Tables"][T]["Row"], values: any[]) => SupabaseFilterBuilder<T>
-  contains: (column: keyof Database["public"]["Tables"][T]["Row"], value: any) => SupabaseFilterBuilder<T>
-  containedBy: (column: keyof Database["public"]["Tables"][T]["Row"], value: any) => SupabaseFilterBuilder<T>
-  rangeGt: (column: keyof Database["public"]["Tables"][T]["Row"], range: string) => SupabaseFilterBuilder<T>
-  rangeGte: (column: keyof Database["public"]["Tables"][T]["Row"], range: string) => SupabaseFilterBuilder<T>
-  rangeLt: (column: keyof Database["public"]["Tables"][T]["Row"], range: string) => SupabaseFilterBuilder<T>
-  rangeLte: (column: keyof Database["public"]["Tables"][T]["Row"], range: string) => SupabaseFilterBuilder<T>
-  rangeAdjacent: (column: keyof Database["public"]["Tables"][T]["Row"], range: string) => SupabaseFilterBuilder<T>
-  overlaps: (column: keyof Database["public"]["Tables"][T]["Row"], value: any) => SupabaseFilterBuilder<T>
-  textSearch: (column: keyof Database["public"]["Tables"][T]["Row"], query: string, options?: { type?: 'plain' | 'phrase' | 'websearch'; config?: string }) => SupabaseFilterBuilder<T>
-  match: (query: Partial<Database["public"]["Tables"][T]["Row"]>) => SupabaseFilterBuilder<T>
-  not: (column: keyof Database["public"]["Tables"][T]["Row"], operator: string, value: any) => SupabaseFilterBuilder<T>
-  or: (filters: string) => SupabaseFilterBuilder<T>
-  filter: (column: keyof Database["public"]["Tables"][T]["Row"], operator: string, value: any) => SupabaseFilterBuilder<T>
+type SupabaseFilterBuilder<T> = {
+  eq: (column: T, value: any) => SupabaseFilterBuilder<any>
+  neq: (column: T, value: any) => SupabaseFilterBuilder<any>
+  gt: (column: T, value: any) => SupabaseFilterBuilder<any>
+  gte: (column: T, value: any) => SupabaseFilterBuilder<any>
+  lt: (column: T, value: any) => SupabaseFilterBuilder<any>
+  lte: (column: T, value: any) => SupabaseFilterBuilder<any>
+  like: (column: T, pattern: string) => SupabaseFilterBuilder<any>
+  ilike: (column: T, pattern: string) => SupabaseFilterBuilder<any>
+  is: (column: T, value: null | boolean) => SupabaseFilterBuilder<any>
+  in: (column: T, values: any[]) => SupabaseFilterBuilder<any>
+  contains: (column: T, value: any) => SupabaseFilterBuilder<any>
+  containedBy: (column: T, value: any) => SupabaseFilterBuilder<any>
+  rangeGt: (column: T, range: string) => SupabaseFilterBuilder<any>
+  rangeGte: (column: T, range: string) => SupabaseFilterBuilder<any>
+  rangeLt: (column: T, range: string) => SupabaseFilterBuilder<any>
+  rangeLte: (column: T, range: string) => SupabaseFilterBuilder<any>
+  rangeAdjacent: (column: T, range: string) => SupabaseFilterBuilder<any>
+  overlaps: (column: T, value: any) => SupabaseFilterBuilder<any>
+  textSearch: (column: T, query: string, options?: { type?: 'plain' | 'phrase' | 'websearch'; config?: string }) => SupabaseFilterBuilder<any>
+  match: (query: T) => SupabaseFilterBuilder<any>
+  not: (column: T, operator: string, value: any) => SupabaseFilterBuilder<any>
+  or: (filters: string) => SupabaseFilterBuilder<any>
+  filter: (column: T, operator: string, value: any) => SupabaseFilterBuilder<any>
 }
 
-interface Props<T = any, Q extends TableKeys = TableKeys> extends Omit<DataTableProps<T>, "sort"> {
-  table?: Q
+type KeysOfTableOrView<T extends AllKeys> =
+  T extends keyof Database["public"]["Tables"]
+  ? keyof Database["public"]["Tables"][T]["Row"]
+  : T extends keyof Database["public"]["Views"]
+  ? keyof Database["public"]["Views"][T]["Row"]
+  : never
+
+type AllKeys = TableKeys | ViewKeys
+
+interface Props<Q extends AllKeys> extends Omit<DataTableProps, "sort"> {
+  table: Q
   select?: string
-  filter?: (builder: SupabaseFilterBuilder<this["table"]>) => SupabaseFilterBuilder<this["table"]>
-  sort?: [keyof Database["public"]["Tables"][Q]["Row"], "asc" | "desc"]
+  filter?: (builder: SupabaseFilterBuilder<KeysOfTableOrView<Q>>) => SupabaseFilterBuilder<any>
+  sort?: [KeysOfTableOrView<Q>, "asc" | "desc"]
   realtime?: boolean
   realtTimeThrottle?: number
 }
+
+// interface Props<T = any, Q extends TableKeys = TableKeys, V extends ViewKeys = ViewKeys> extends Omit<DataTableProps<T>, "sort"> {
+//   table?: Q
+//   select?: string
+//   filter?: (builder: SupabaseFilterBuilder<keyof Database["public"]["Tables"][Q]["Row"]>) => SupabaseFilterBuilder<any>
+//   // filter?: (builder: SupabaseFilterBuilder<this["table"]>) => SupabaseFilterBuilder<this["table"]>
+//   sort?: [keyof Database["public"]["Tables"][Q]["Row"], "asc" | "desc"]
+//   realtime?: boolean
+//   realtTimeThrottle?: number
+// }
 
 async function readFromSupabase({ table, select, filter, orderBy, page, pageSize }: { table: string, select: string, filter: any, orderBy: any, page: number, pageSize: number }) {
   let sbq = supabase.from(table as any).select(select, { count: 'exact' })
@@ -59,7 +77,7 @@ async function readFromSupabase({ table, select, filter, orderBy, page, pageSize
 
 function defaultFilter(q: any) { return q }
 
-export function DataTableSupabase<T = any, Q extends TableKeys = TableKeys>(props: Props<T, Q>) {
+export function DataTableSupabase<Q extends AllKeys>(props: Props<Q>) {
 
   const {
     table,
@@ -68,12 +86,13 @@ export function DataTableSupabase<T = any, Q extends TableKeys = TableKeys>(prop
     sort,
     realtime,
     realtTimeThrottle = 2000,
+    onActionExecuted,
     ...rest
   } = props
 
   const [realTime, setRealTime] = useState(false)
   const [{ pageIndex: page, pageSize }, setPage] = useMultiState<PaginationData>({ pageIndex: 0, pageSize: 20 })
-  const [sortInfo, setSortInfo] = useState<[keyof Database["public"]["Tables"][Q]["Row"], "asc" | "desc"] | null>(sort)
+  const [sortInfo, setSortInfo] = useState<[any, "asc" | "desc"] | null>(sort)
   const update = useForceUpdate()
 
   const state = useRef({
@@ -83,6 +102,7 @@ export function DataTableSupabase<T = any, Q extends TableKeys = TableKeys>(prop
     realTimeListening: false,
     readyForRealTime: false,
     error: "",
+    version: 0, //used to force a reload
   })
 
   async function loadData() {
@@ -99,7 +119,6 @@ export function DataTableSupabase<T = any, Q extends TableKeys = TableKeys>(prop
         error = null
         break
       }
-      // console.log(`Awaiting delay ${d}ms`)
       await delay(d)
       console.log(`Retrying ${n + 1}...`)
       d += 1000
@@ -122,8 +141,7 @@ export function DataTableSupabase<T = any, Q extends TableKeys = TableKeys>(prop
       state.current.readyForRealTime = true
       update()
     })
-    // }, [table, select, filter, sort, page, pageSize])
-  }, [table, select, filter, sortInfo, page, pageSize])
+  }, [table, select, filter, sortInfo, page, pageSize, state.current.version])
 
 
   useEffect(() => {
@@ -159,6 +177,11 @@ export function DataTableSupabase<T = any, Q extends TableKeys = TableKeys>(prop
     setSortInfo((direction ? [field, direction] : null) as any)
   }
 
+  async function aexec() {
+    state.current.version++
+    update()
+  }
+
   return <DataTable
     {...rest as any}
     loading={state.current.loading}
@@ -167,6 +190,7 @@ export function DataTableSupabase<T = any, Q extends TableKeys = TableKeys>(prop
     onPaginationChange={onPaginationChange}
     onSortingChange={onSortingChange}
     total={state.current.count}
+    onActionExecuted={onActionExecuted || aexec}
   >
     {props.children}
     {realtime && <ToolbarItem>

--- a/src/components/declarativemenu.tsx
+++ b/src/components/declarativemenu.tsx
@@ -1,34 +1,108 @@
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuPortal, DropdownMenuSub, DropdownMenuSubContent, DropdownMenuSubTrigger, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "./ui/alert-dialog"
+import React, { useRef } from "react"
 
 declare global {
   interface DropdownMenuContent {
     title?: string
     icon?: any
-    action?: () => void
+    action?: (v?: any) => void
+    ask?: string
     items?: DropdownMenuContent[]
   }
   type DropdownMenuContents = DropdownMenuContent[]
 }
 
+
 interface Props {
   children: any
   menu: DropdownMenuContents
+  reference?: any
+  onActionExecuted?: () => Promise<void>
 }
 
-function RenderMenu({ menu }: { menu: DropdownMenuContents }) {
+
+export function DeclarativeMenu({ children, menu, reference, onActionExecuted }: Props) {
+
+  const state = useRef({
+    ask: "",
+    action: () => { },
+  })
+  const [open, setOpen] = React.useState(false)
+
+  function onShowDialog(ask: string, action: (v?: any) => void) {
+    state.current.ask = ask
+    state.current.action = action
+    setOpen(true)
+  }
+  async function onExecuteAction() {
+    state.current.action()
+    setOpen(false)
+    if (onActionExecuted) await onActionExecuted()
+  }
+
+  return <>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        {children}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <RenderMenu menu={menu} reference={reference} showDialog={onShowDialog} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+    <AlertDialog open={open} onOpenChange={setOpen} >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{state.current.ask}</AlertDialogTitle>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onExecuteAction}>Continue</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  </>
+
+
+}
+
+interface RenderMenuProps {
+  menu: DropdownMenuContents
+  reference?: any
+  showDialog?: (ask: string, action: (v?: any) => void) => void
+  onActionExecuted?: () => Promise<void>
+}
+
+function RenderMenu({ menu, reference, showDialog, onActionExecuted }: RenderMenuProps) {
 
   return menu.map((item, index) => {
+
     if (item.items) {
       return <DropdownMenuSub>
         <DropdownMenuSubTrigger>{item.title}</DropdownMenuSubTrigger>
         <DropdownMenuPortal>
           <DropdownMenuSubContent>
-            <RenderMenu menu={item.items} />
+            <RenderMenu menu={item.items} showDialog={showDialog} onActionExecuted={onActionExecuted} />
           </DropdownMenuSubContent>
         </DropdownMenuPortal>
       </DropdownMenuSub>
     }
-    return <DropdownMenuItem key={index} onClick={item.action}>
+
+    if (!item.ask) {
+      return <DropdownMenuItem key={index} onClick={(e) => {
+        e.stopPropagation()
+        item.action(reference)
+        if (onActionExecuted) onActionExecuted()
+      }}>
+        {item.icon}
+        {item.title}
+      </DropdownMenuItem>
+    }
+
+    return <DropdownMenuItem key={index} onClick={(e) => {
+      e.stopPropagation()
+      showDialog(item.ask, () => item.action(reference))
+    }}>
       {item.icon}
       {item.title}
     </DropdownMenuItem>
@@ -36,16 +110,4 @@ function RenderMenu({ menu }: { menu: DropdownMenuContents }) {
 
 }
 
-export function DeclarativeMenu({ children, menu }: Props) {
 
-  return <DropdownMenu>
-    <DropdownMenuTrigger asChild>
-      {children}
-    </DropdownMenuTrigger>
-    <DropdownMenuContent>
-      <RenderMenu menu={menu} />
-    </DropdownMenuContent>
-  </DropdownMenu>
-
-
-}

--- a/src/components/page/crudloader.tsx
+++ b/src/components/page/crudloader.tsx
@@ -2,8 +2,6 @@ import { Skeleton } from "../ui/skeleton"
 import { Page } from "./page"
 import { PageTitle } from "./title"
 
-
-
 export function CRUDLoader() {
 
   return <Page>
@@ -37,64 +35,5 @@ export function CRUDLoader() {
       </div>
     </div>
   </Page>
-
-  return <div className="">
-    <div className="flex flex-col space-y-4 pt-16 px-4">
-      <div className="row">
-        <Skeleton className="h-8 rounded-md rc-4" />
-        <Skeleton className="h-8 rounded-md rc-4" />
-        <Skeleton className="h-8 rounded-md rc-4" />
-      </div>
-      <Skeleton className="h-32 w-full rounded-md" />
-      <div className="row">
-        <Skeleton className="h-8 rounded-md rc-4" />
-        <Skeleton className="h-8 rounded-md rc-8" />
-      </div>
-      <div className="row">
-        <Skeleton className="h-8 rounded-md rc-2" />
-        <Skeleton className="h-8 rounded-md rc-2" />
-        <Skeleton className="h-8 rounded-md rc-8" />
-      </div>
-      <div className="row">
-        <Skeleton className="h-8 rounded-md rc-2" />
-        <Skeleton className="h-8 rounded-md rc-2" />
-        <Skeleton className="h-8 rounded-md rc-8" />
-      </div>
-      <div className="row">
-        <div className="rc-10" />
-        <Skeleton className="h-8 rounded-md rc-2" />
-      </div>
-    </div>
-  </div>
-
-  return <div className="">
-    <div className="flex flex-col space-y-4 pt-16 px-4">
-      <div className="row">
-        <Skeleton className="h-8 rounded-md rc-4" />
-        <Skeleton className="h-8 rounded-md rc-4" />
-        <Skeleton className="h-8 rounded-md rc-4" />
-      </div>
-      <Skeleton className="h-32 w-full rounded-md" />
-      <div className="row">
-        <Skeleton className="h-8 rounded-md rc-4" />
-        <Skeleton className="h-8 rounded-md rc-8" />
-      </div>
-      <div className="row">
-        <Skeleton className="h-8 rounded-md rc-2" />
-        <Skeleton className="h-8 rounded-md rc-2" />
-        <Skeleton className="h-8 rounded-md rc-8" />
-      </div>
-      <div className="row">
-        <Skeleton className="h-8 rounded-md rc-2" />
-        <Skeleton className="h-8 rounded-md rc-2" />
-        <Skeleton className="h-8 rounded-md rc-8" />
-      </div>
-      <div className="row">
-        <div className="rc-10" />
-        <Skeleton className="h-8 rounded-md rc-2" />
-      </div>
-    </div>
-
-  </div>
 
 }

--- a/src/components/page/crudtoolbar.tsx
+++ b/src/components/page/crudtoolbar.tsx
@@ -1,0 +1,95 @@
+import { useFormContext } from "react-hook-form"
+import { Button } from "../ui/button"
+import { Check, Trash2 } from "lucide-react"
+import { useEffect, useRef } from "react"
+import { usePage } from "./hooks"
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "../ui/alert-dialog"
+import { useNavigate } from "react-router-dom"
+import { supabase } from "@/lib/data"
+
+interface Props {
+  table: TableKeys
+  onSuccess?: (() => void) | string
+}
+
+export function CRUDToolbar(props: Props) {
+
+  let { table } = props
+  const navigate = useNavigate()
+
+  const { subscribe } = useFormContext()
+  const { id, config } = usePage()
+  const state = useRef({
+    canSubmit: false
+  })
+
+  useEffect(() => {
+    const callback = subscribe({
+      formState: {
+        values: true,
+        isDirty: true,
+        dirtyFields: true,
+        touchedFields: true,
+        isValid: true,
+        errors: true,
+        validatingFields: true,
+        isValidating: true
+      },
+      callback: (s) => {
+        state.current.canSubmit = true
+        if (!s.isReady || s.disabled || s.isLoading || s.isValidating) {
+          state.current.canSubmit = false
+        }
+      },
+    })
+    return () => callback()
+  }, [subscribe])
+
+  const { canSubmit } = state.current
+
+  function success() {
+    if (props.onSuccess) {
+      if (typeof props.onSuccess === "string") {
+        navigate(props.onSuccess)
+      } else {
+        props.onSuccess()
+      }
+    }
+  }
+
+  async function onDelete() {
+    console.log("Deleting", id)
+    await supabase.from(table as any).delete().eq('id', id)
+    success()
+  }
+
+  return <div className="flex  gap-2">
+    {id && <>
+      <AlertDialog>
+        <AlertDialogTrigger>
+          <Button type="button" variant="destructive" className="rounded-full size-8" >
+            <Trash2 strokeWidth={2} />
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={onDelete}>Continue</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>}
+    <Button type="submit" className="rounded-full size-8" disabled={!canSubmit}>
+      <Check strokeWidth={4} />
+    </Button>
+  </div>
+
+
+}
+

--- a/src/components/page/page.tsx
+++ b/src/components/page/page.tsx
@@ -1,8 +1,10 @@
+import { Toaster } from "sonner"
 
 export function Page(props: React.HTMLAttributes<HTMLDivElement>) {
   const { children } = props
   return <div className="flex flex-col flex-1 p-4 overflow-y-auto min-h-0 h-full" id="page" {...props}>
     {children}
+    <Toaster />
   </div>
 }
 

--- a/src/components/page/title.tsx
+++ b/src/components/page/title.tsx
@@ -1,16 +1,33 @@
+import { useFormContext } from "react-hook-form"
 import { usePage } from "./hooks"
 
-export function PageTitle() {
+interface Props {
+  children?: React.ReactNode
+}
+
+export function PageTitle(props: Props) {
+
   const { config } = usePage()
 
-  return <div className="flex flex-col gap-2">
-    <div>
-      <div className="flex items-center">
-        {config.icon && <config.icon className="mr-2" />}
-        <h1 className="text-2xl font-bold">{config?.title ?? ""}</h1>
+
+  return <div className="flex">
+    <div className="flex flex-col gap-2">
+      <div>
+        <div className="flex items-center">
+          {config.icon && <config.icon className="mr-2" />}
+          <h1 className="text-2xl font-bold">{config?.title ?? ""}</h1>
+        </div>
       </div>
+      <div className="text-muted-foreground">{config?.description ?? ""}</div>
     </div>
-    <div className="text-muted-foreground">{config?.description ?? ""}</div>
+    {props.children && <>
+      <div className="grow"></div>
+      <div>
+        {props.children}
+      </div>
+    </>}
   </div>
+
+
 }
 

--- a/src/lib/data/db.ts
+++ b/src/lib/data/db.ts
@@ -7,7 +7,9 @@ export const supabase = createClient<Database>(env.SUPABASE_URL, env.SUPABASE_AN
 declare global {
 
   type TableKeys = keyof Database["public"]["Tables"]
+  type ViewKeys = keyof Database["public"]["Views"]
   type Table<T extends TableKeys> = Database["public"]["Tables"][T]["Row"]
+  type View<T extends ViewKeys> = Database["public"]["Views"][T]["Row"]
 
 }
 

--- a/src/lib/pages.tsx
+++ b/src/lib/pages.tsx
@@ -1,32 +1,40 @@
-import { PageContext } from "@/components/page/hooks"
-import { ContextualPage } from "@/components/page/pagecontext"
-import { agents } from "@/pages/agents"
+import { agents } from "@/pages/dev/agents"
+import { apikeys } from "@/pages/dev/apikeys"
 import { dev_dtprops } from "@/pages/dev/dtprops"
 import { dev_external } from "@/pages/dev/external"
-import { logsdev } from "@/pages/dev/logs"
+import { logsdev } from "@/pages/dev/agentlogs"
 import { models } from "@/pages/dev/models"
 import { models_crud } from "@/pages/dev/models/model"
-import { Code, Logs, Settings, Settings2, type LucideIcon } from "lucide-react"
+import { projects } from "@/pages/dev/projects"
+import { roles } from "@/pages/dev/roles"
+import { teams } from "@/pages/dev/teams"
+import { users } from "@/pages/dev/users"
+import { Book, Code, Logs, Settings2, type LucideIcon } from "lucide-react"
+import { templates } from "@/pages/dev/templates"
+import { collections } from "@/pages/dev/collections"
+import { sources } from "@/pages/dev/sources"
 
 export const pages: Record<string, PageConfig> = {
   agents,
+  templates,
   dev_external,
   logsdev,
   dev_dtprops,
+  projects,
+  teams,
+  apikeys,
   models,
   models_crud,
+  users,
+  roles,
+  collections,
+  sources,
 }
 
-// for (const key in pages) {
-//   const page = pages[key]
-//   page.component = <ContextualPage config={page}><page.component /></ContextualPage> as any
-// }
-
-
 export const groups = {
-  evaluation: { title: "Evaluation (Dev)", icon: Logs },
-  knowledge: { title: "Knowledge" },
-  settings: { title: "Settings (Dev)", icon: Settings2 },
+  evaluation: { title: "Evaluation 🧪", icon: Logs },
+  knowledge: { title: "Knowledge 🧪", icon: Book },
+  settings: { title: "Settings 🧪", icon: Settings2 },
   dev: { title: "Dev", icon: Code },
 } satisfies Record<string, Group>
 
@@ -52,4 +60,3 @@ declare global {
   }
 
 }
-

--- a/src/pages/dev/agentlogs/index.tsx
+++ b/src/pages/dev/agentlogs/index.tsx
@@ -35,7 +35,7 @@ function component() {
   return <Page >
     <div className="h-full grid grid-rows-[auto,1fr] gap-4">
       <PageTitle />
-      <DataTableSupabase columns={columns} hideActions hideSelection table="logs" realtime sort={["created_at", "desc"]}>
+      <DataTableSupabase columns={columns} hideSelection table="logs" realtime sort={["created_at", "desc"]}>
       </DataTableSupabase>
     </div>
   </Page>

--- a/src/pages/dev/agents/index.tsx
+++ b/src/pages/dev/agents/index.tsx
@@ -1,0 +1,69 @@
+import { Page, PageTitle } from "@/components/page"
+import { BrainIcon, Plus, Sparkles } from "lucide-react"
+import { DataTableSupabase } from "@/components/datatable/supadatatable"
+import { DataTable } from "@/components/datatable/datatable"
+import { useTeamStore } from "@/lib/hooks/useTeam"
+import { Button } from "@/components/ui/button"
+import { useNavigate } from "react-router-dom"
+import { DeclarativeMenu } from "@/components/declarativemenu"
+
+export const agents = {
+  title: "Agents 🧪",
+  description: "Manage your agents and their configurations.",
+  route: "/agents",
+  url: "/agents",
+  icon: BrainIcon,
+  component,
+  resource: "agents",
+  action: "read",
+} satisfies PageConfig
+
+const columns: Columns<Table<"agents">> = {
+  id: { header: "ID", cell: DataTable.cellRender.number, size: 64 },
+  title: { header: "Title", size: 620 },
+  created_at: { header: "Created", cell: DataTable.cellRender.date, size: 166 },
+  description: { header: "Description", size: 380 },
+}
+
+function component() {
+
+  const { selectedTeam } = useTeamStore()
+  const navigate = useNavigate()
+
+  const menu = [
+    { title: "New Agent", action: () => navigate('/agent/new'), icon: <Plus /> },
+    { title: "From Template", action: () => console.log("From Template") },
+    { title: "Auto-Generate", action: () => console.log("Auto-Generate"), icon: <Sparkles /> },
+  ] satisfies DropdownMenuContents
+
+
+  return <Page>
+    <div className="h-full grid grid-rows-[auto,1fr] gap-4">
+      <div className="flex">
+        <PageTitle />
+        <div className="grow"></div>
+        <div>
+          <DeclarativeMenu menu={menu}>
+            <Button className="rounded-lg"><Plus className="h-4 w-4" />Create Agent</Button>
+          </DeclarativeMenu>
+        </div>
+      </div>
+      <DataTableSupabase
+        table="agents"
+        hideSelection
+        columns={columns}
+        onRowClick={"/agent"}
+        sort={["created_at", "desc"]}
+        filter={q => q.eq("team_id", selectedTeam?.id)}
+      // select={`
+      //   *,
+      //   agent (
+      //     name
+      //   )
+      // `}
+      />
+    </div>
+  </Page>
+
+}
+

--- a/src/pages/dev/apikeys/index.tsx
+++ b/src/pages/dev/apikeys/index.tsx
@@ -3,25 +3,32 @@ import { DataTableSupabase } from "@/components/datatable/supadatatable"
 import { Page, PageTitle } from "@/components/page"
 import { Button } from "@/components/ui/button"
 import { supabase } from "@/lib/data"
-import { Box, Plus, Trash2 } from "lucide-react"
+import { Key, Plus, Trash2 } from "lucide-react"
 import { useNavigate } from "react-router-dom"
+import { Database } from "@/lib/agents/supabase"
 
-export const models = {
-  title: "Models",
-  description: "Manage your organization's AI Models.",
-  route: "/settings/modelsd",
-  url: "/settings/modelsd",
-  icon: Box,
+
+export const apikeys = {
+  title: "API Keys",
+  description: "Manage your organization's API Keys.",
+  route: "/settings/apikeysd",
+  url: "/settings/apikeysd",
+  icon: Key,
   component,
   group: "settings",
-  resource: "models",
+  resource: "apikeys",
   action: "read",
 } satisfies PageConfig
 
-const columns: Columns<Table<"models">> = {
-  title: { header: "Title", size: 600 },
-  model: { header: "Model", size: 340 },
-  provider: { header: "Provider", size: 120 },
+const columns: Columns<Table<"api_keys">> = {
+  type: { header: "Type", size: 150 },
+  description: { header: "Description", size: 500 },
+  key: {
+    header: "Key", size: 420, cell: ({ row }) => {
+      const value = row.original.key
+      return value ? "••••••••" + value.slice(-4) : "Not set"
+    }
+  },
   created_at: { header: "Created", cell: DataTable.cellRender.date, size: 166 },
 }
 
@@ -32,10 +39,10 @@ function component() {
   const menu = [
     {
       title: "Delete", action: async (v) => {
-        await supabase.from("models").delete().eq("id", v.id)
+        await supabase.from("api_keys").delete().eq("id", v.id)
       },
       icon: <Trash2 />,
-      ask: "Are you sure you want to delete this model?",
+      ask: "Are you sure you want to delete this API key?",
     },
   ] satisfies DropdownMenuContents
 
@@ -46,14 +53,14 @@ function component() {
         <PageTitle />
         <div className="grow"></div>
         <div>
-          <Button className="rounded-lg" onClick={() => navigate('/settings/modelsd/new')}><Plus className="h-4 w-4" />New Model</Button>
+          <Button className="rounded-lg" onClick={() => navigate('/settings/apikeysd/new')}><Plus className="h-4 w-4" />New API Key</Button>
         </div>
       </div>
       <DataTableSupabase
-        table="models"
+        table="api_keys"
         columns={columns}
         hideSelection
-        onRowClick={"/settings/modelsd"}
+        onRowClick={"/settings/apikeysd"}
         sort={["created_at", "desc"]}
         actions={menu}
       />
@@ -61,4 +68,3 @@ function component() {
   </Page>
 
 }
-

--- a/src/pages/dev/collections/index.tsx
+++ b/src/pages/dev/collections/index.tsx
@@ -1,0 +1,96 @@
+import { DataTable } from "@/components/datatable/datatable"
+import { DataTableSupabase } from "@/components/datatable/supadatatable"
+import { Page, PageTitle } from "@/components/page"
+import { Button } from "@/components/ui/button"
+import { Book, Box, Plus, Trash2 } from "lucide-react"
+import { useNavigate } from "react-router-dom"
+import { usePage } from "@/components/page/hooks"
+import { calculateVectorPercentage } from "@/pages/knowledge/utils"
+
+export const collections = {
+  title: "Collections",
+  description: "Manage your organization's AI Collections.",
+  route: "/settings/collectionsd",
+  url: "/settings/collectionsd",
+  icon: Book,
+  component,
+  group: "knowledge",
+  resource: "collections",
+  action: "read",
+} satisfies PageConfig
+
+const columns: Columns<View<"collections_with_counts">> = {
+  name: { header: "Name", size: 400 },
+  sourceCount: { header: "Sources", size: 120, cell: DataTable.cellRender.number },
+  vectorizedCount: {
+    header: "Vector Status",
+    size: 400,
+    accessorFn: row => row.sourceCount > 0 ? row.vectorizedCount / row.sourceCount : 0,
+    cell: ({ row }) => {
+      const vectorizedCount = typeof row.original.vectorizedCount === 'number' && !isNaN(row.original.vectorizedCount) ? row.original.vectorizedCount : 0
+      const sourceCount = typeof row.original.sourceCount === 'number' && !isNaN(row.original.sourceCount) ? row.original.sourceCount : 0
+      const vectorPercentage = calculateVectorPercentage(vectorizedCount, sourceCount)
+      return (
+        <div className="space-y-1">
+          <div className="flex items-center justify-between text-xs">
+            <span>
+              {vectorizedCount} / {sourceCount} sources
+            </span>
+            <span>{vectorPercentage}%</span>
+          </div>
+          <div className="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
+            <div
+              className="bg-blue-600 h-2.5 rounded-full"
+              style={{ width: `${vectorPercentage}%` }}
+            ></div>
+          </div>
+        </div>
+      )
+    },
+    sortingFn: (a, b) => {
+      const aPercent = a.original.sourceCount > 0 ? (a.original.vectorizedCount / a.original.sourceCount) : 0
+      const bPercent = b.original.sourceCount > 0 ? (b.original.vectorizedCount / b.original.sourceCount) : 0
+      return aPercent - bPercent
+    },
+  },
+  team_id: {
+    header: "Team", size: 200,
+    cell: ({ row }) => row.original.team_id["name"],
+  },
+  created_at: { header: "Created", cell: DataTable.cellRender.date, size: 166 },
+}
+
+
+function component() {
+
+  const navigate = useNavigate()
+  const { team } = usePage()
+
+  return <Page>
+    <div className="h-full grid grid-rows-[auto,1fr] gap-4">
+      <div className="flex">
+        <PageTitle />
+        <div className="grow"></div>
+        <div>
+          <Button className="rounded-lg" onClick={() => navigate('/settings/collectionsd/new')}><Plus className="h-4 w-4" />New Source</Button>
+        </div>
+      </div>
+      <DataTableSupabase
+        table="collections_with_counts"
+        columns={columns}
+        hideSelection
+        onRowClick={"/settings/collectionsd"}
+        sort={["created_at", "desc"]}
+        filter={q => q.eq("team_id", team?.id)}
+        select={`
+        *,
+        team_id (
+          name
+        )
+      `}
+      />
+    </div>
+  </Page>
+
+}
+

--- a/src/pages/dev/dtprops.tsx
+++ b/src/pages/dev/dtprops.tsx
@@ -36,7 +36,7 @@ function component() {
     onLoad().then((data) => setData(data))
   }, [])
 
-  return <Page >
+  return <Page>
     <div className="h-full grid grid-rows-[auto,1fr] gap-4">
       <div className="flex">
         <PageTitle />
@@ -89,7 +89,6 @@ function component() {
         showColumnSelection={showColumnSelection}
         showPagination={showPagination}
         hideSelection={hideSelection}
-        hideActions={hideActions}
         data={showEmptyState ? emptyData : data}
       >
         {showCustomEmpty && <EmptyData>

--- a/src/pages/dev/models/model.tsx
+++ b/src/pages/dev/models/model.tsx
@@ -1,14 +1,14 @@
 import { Page, PageTitle } from "@/components/page"
-import { Button } from "@/components/ui/button"
+import { CRUDLoader } from "@/components/page/crudloader"
+import { CRUDToolbar } from "@/components/page/crudtoolbar"
+import { useDatabaseItem } from "@/components/page/hooks"
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Box } from "lucide-react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
-import { zodResolver } from "@hookform/resolvers/zod"
-import { useDatabaseItem, usePage } from "@/components/page/hooks"
-import { CRUDLoader } from "@/components/page/crudloader"
-import { Box } from "lucide-react"
 
 export const models_crud = {
   title: "Model",
@@ -30,35 +30,37 @@ type FormData = z.infer<typeof FormSchema>
 
 export function component() {
 
-  const { data, loading, id } = useDatabaseItem("models")
+  const { data, loading, submit, toastSuccess, navigate } = useDatabaseItem("models")
 
   const form = useForm<FormData>({
     resolver: zodResolver(FormSchema),
-    defaultValues: data || {},
-    values: data || {},
+    defaultValues: data,
+    values: data,
   })
 
-  console.log("Data: ", data, loading, id)
-
-
-  const onSubmit = async (data: FormData) => {
+  async function onSubmit(data: FormData) {
     console.log("Submit: ", data)
+    await submit(data)
+    toastSuccess()
+    navigate("/settings/modelsd")
   }
 
   if (loading) return <CRUDLoader />
 
   return <Page>
     <div className="pb-8">
-      <PageTitle />
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)}>
+          <PageTitle>
+            <CRUDToolbar table="models" onSuccess={"/settings/modelsd"} />
+          </PageTitle>
           <div className="rgrid">
             <div className="row">
               <div className="rc-4">
                 <FormField control={form.control} name="provider" render={({ field }) => (
                   <FormItem>
                     <FormLabel>Provider</FormLabel>
-                    <Select {...field}>
+                    <Select value={field.value} onValueChange={field.onChange} defaultValue={field.value}>
                       <FormControl>
                         <SelectTrigger>
                           <SelectValue placeholder="Select a provider" />
@@ -94,11 +96,9 @@ export function component() {
               </div>
             </div>
           </div>
-          <div className="flex justify-end">
-            <Button type="submit" className="mt-4" disabled={form.formState.isSubmitting}>Save</Button>
-          </div>
         </form>
       </Form>
     </div>
   </Page>
+
 }

--- a/src/pages/dev/projects/index.tsx
+++ b/src/pages/dev/projects/index.tsx
@@ -3,26 +3,27 @@ import { DataTableSupabase } from "@/components/datatable/supadatatable"
 import { Page, PageTitle } from "@/components/page"
 import { Button } from "@/components/ui/button"
 import { supabase } from "@/lib/data"
-import { Box, Plus, Trash2 } from "lucide-react"
+import { Box, Folder, Plus, Trash2 } from "lucide-react"
 import { useNavigate } from "react-router-dom"
 
-export const models = {
-  title: "Models",
-  description: "Manage your organization's AI Models.",
-  route: "/settings/modelsd",
-  url: "/settings/modelsd",
-  icon: Box,
+export const projects = {
+  title: "Projects",
+  description: "Manage your organization's projects and team assignments.",
+  route: "/settings/projectsd",
+  url: "/settings/projectsd",
+  icon: Folder,
   component,
   group: "settings",
-  resource: "models",
+  resource: "projects",
   action: "read",
 } satisfies PageConfig
 
-const columns: Columns<Table<"models">> = {
-  title: { header: "Title", size: 600 },
-  model: { header: "Model", size: 340 },
-  provider: { header: "Provider", size: 120 },
-  created_at: { header: "Created", cell: DataTable.cellRender.date, size: 166 },
+const columns: Columns<Table<"projects">> = {
+  name: { header: "Name", size: 200 },
+  description: { header: "Description", size: 550 },
+  status: { header: "Status", size: 100 },
+  team: { header: "Team", size: 200 },
+  created_at: { header: "Model", size: 200, cell: DataTable.cellRender.date, },
 }
 
 function component() {
@@ -32,10 +33,10 @@ function component() {
   const menu = [
     {
       title: "Delete", action: async (v) => {
-        await supabase.from("models").delete().eq("id", v.id)
+        await supabase.from("projects").delete().eq("id", v.id)
       },
       icon: <Trash2 />,
-      ask: "Are you sure you want to delete this model?",
+      ask: "Are you sure you want to delete this Project?",
     },
   ] satisfies DropdownMenuContents
 
@@ -46,14 +47,14 @@ function component() {
         <PageTitle />
         <div className="grow"></div>
         <div>
-          <Button className="rounded-lg" onClick={() => navigate('/settings/modelsd/new')}><Plus className="h-4 w-4" />New Model</Button>
+          <Button className="rounded-lg" onClick={() => navigate('/settings/projectsd/new')}><Plus className="h-4 w-4" />New Project</Button>
         </div>
       </div>
       <DataTableSupabase
-        table="models"
+        table="projects"
         columns={columns}
         hideSelection
-        onRowClick={"/settings/modelsd"}
+        onRowClick={"/settings/projectsd"}
         sort={["created_at", "desc"]}
         actions={menu}
       />

--- a/src/pages/dev/roles/index.tsx
+++ b/src/pages/dev/roles/index.tsx
@@ -3,25 +3,27 @@ import { DataTableSupabase } from "@/components/datatable/supadatatable"
 import { Page, PageTitle } from "@/components/page"
 import { Button } from "@/components/ui/button"
 import { supabase } from "@/lib/data"
-import { Box, Plus, Trash2 } from "lucide-react"
+import { Database } from "@/lib/agents/supabase"
+import { Shield, Plus, Trash2 } from "lucide-react"
 import { useNavigate } from "react-router-dom"
 
-export const models = {
-  title: "Models",
-  description: "Manage your organization's AI Models.",
-  route: "/settings/modelsd",
-  url: "/settings/modelsd",
-  icon: Box,
+
+export const roles = {
+  title: "Roles",
+  description: "Manage your organization's user roles and permissions.",
+  route: "/settings/rolesd",
+  url: "/settings/rolesd",
+  icon: Shield,
   component,
   group: "settings",
-  resource: "models",
+  resource: "roles",
   action: "read",
 } satisfies PageConfig
 
-const columns: Columns<Table<"models">> = {
-  title: { header: "Title", size: 600 },
-  model: { header: "Model", size: 340 },
-  provider: { header: "Provider", size: 120 },
+const columns: Columns<Table<"roles">> = {
+  name: { header: "Name", size: 300 },
+  description: { header: "Description", size: 400 },
+  team_id: { header: "Team", size: 400 },
   created_at: { header: "Created", cell: DataTable.cellRender.date, size: 166 },
 }
 
@@ -32,10 +34,10 @@ function component() {
   const menu = [
     {
       title: "Delete", action: async (v) => {
-        await supabase.from("models").delete().eq("id", v.id)
+        await supabase.from("roles").delete().eq("id", v.id)
       },
       icon: <Trash2 />,
-      ask: "Are you sure you want to delete this model?",
+      ask: "Are you sure you want to delete this role?",
     },
   ] satisfies DropdownMenuContents
 
@@ -46,14 +48,14 @@ function component() {
         <PageTitle />
         <div className="grow"></div>
         <div>
-          <Button className="rounded-lg" onClick={() => navigate('/settings/modelsd/new')}><Plus className="h-4 w-4" />New Model</Button>
+          <Button className="rounded-lg" onClick={() => navigate('/settings/rolesd/new')}><Plus className="h-4 w-4" />New Role</Button>
         </div>
       </div>
       <DataTableSupabase
-        table="models"
+        table="roles"
         columns={columns}
         hideSelection
-        onRowClick={"/settings/modelsd"}
+        onRowClick={"/settings/rolesd"}
         sort={["created_at", "desc"]}
         actions={menu}
       />
@@ -61,4 +63,3 @@ function component() {
   </Page>
 
 }
-

--- a/src/pages/dev/sources/index.tsx
+++ b/src/pages/dev/sources/index.tsx
@@ -1,0 +1,101 @@
+import { DataTable } from "@/components/datatable/datatable"
+import { DataTableSupabase } from "@/components/datatable/supadatatable"
+import { Page, PageTitle } from "@/components/page"
+import { Button } from "@/components/ui/button"
+import { Book, Box, Plus, Trash2 } from "lucide-react"
+import { useNavigate } from "react-router-dom"
+import { usePage } from "@/components/page/hooks"
+import { calculateVectorPercentage } from "@/pages/knowledge/utils"
+
+export const sources = {
+  title: "Sources",
+  description: "Manage your data sources and their content.",
+  route: "/settings/sourcesd",
+  url: "/settings/sourcesd",
+  icon: Book,
+  component,
+  group: "knowledge",
+  resource: "sources",
+  action: "read",
+} satisfies PageConfig
+
+const columns: Columns<Table<"sources">> = {
+  name: { header: "Name", size: 400 },
+  tags: {
+    header: "Tags",
+    size: 200,
+    cell: ({ row }) => (
+      <div className="flex flex-wrap gap-1">
+        {row.original.tags.map((tag: string) => {
+          let tagStyle = "bg-muted"
+          if (tag === 'File Upload') {
+            tagStyle = "bg-blue-100 text-blue-800"
+          } else if (tag === 'Live Data') {
+            tagStyle = "bg-purple-100 text-purple-800"
+          }
+          return (
+            <span
+              key={tag}
+              className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs ${tagStyle}`}
+            >
+              {tag}
+            </span>
+          )
+        })}
+      </div>
+    ),
+  },
+  type: { header: "Type", size: 100 },
+  vector: {
+    header: "Vector",
+    size: 100,
+    cell: ({ row }) => (
+      row.original.vector ? (
+        <span className="text-green-600 font-semibold">Yes</span>
+      ) : (
+        <span className="text-gray-400">No</span>
+      )
+    ),
+  },
+  team_id: {
+    header: "Team", size: 200,
+    cell: ({ row }) => row.original.team_id["name"],
+  },
+  created_at: { header: "Created", cell: DataTable.cellRender.date, size: 166 },
+  last_updated: { header: "Updated", cell: DataTable.cellRender.date, size: 166 },
+}
+
+
+function component() {
+
+  const navigate = useNavigate()
+  const { team } = usePage()
+
+  return <Page>
+    <div className="h-full grid grid-rows-[auto,1fr] gap-4">
+      <div className="flex">
+        <PageTitle />
+        <div className="grow"></div>
+        <div>
+          <Button className="rounded-lg" onClick={() => navigate('/settings/sourcesd/new')}><Plus className="h-4 w-4" />New Model</Button>
+        </div>
+      </div>
+      <DataTableSupabase
+        table="sources"
+        columns={columns}
+        hideSelection
+        onRowClick={"/settings/sourcesd"}
+        sort={["created_at", "desc"]}
+        filter={q => q.eq("team_id", team?.id)}
+        select={`
+        *,
+        team_id (
+          name
+        )
+      `}
+      />
+    </div>
+  </Page>
+
+}
+

--- a/src/pages/dev/teams/index.tsx
+++ b/src/pages/dev/teams/index.tsx
@@ -3,25 +3,25 @@ import { DataTableSupabase } from "@/components/datatable/supadatatable"
 import { Page, PageTitle } from "@/components/page"
 import { Button } from "@/components/ui/button"
 import { supabase } from "@/lib/data"
-import { Box, Plus, Trash2 } from "lucide-react"
+import { Users, Plus, Trash2 } from "lucide-react"
 import { useNavigate } from "react-router-dom"
 
-export const models = {
-  title: "Models",
-  description: "Manage your organization's AI Models.",
-  route: "/settings/modelsd",
-  url: "/settings/modelsd",
-  icon: Box,
+export const teams = {
+  title: "Teams",
+  description: "Manage your organization's teams.",
+  route: "/settings/teamsd",
+  url: "/settings/teamsd",
+  icon: Users,
   component,
   group: "settings",
-  resource: "models",
+  resource: "teams",
   action: "read",
 } satisfies PageConfig
 
-const columns: Columns<Table<"models">> = {
-  title: { header: "Title", size: 600 },
-  model: { header: "Model", size: 340 },
-  provider: { header: "Provider", size: 120 },
+const columns: Columns<Table<"teams">> = {
+  name: { header: "Name", size: 300 },
+  description: { header: "Description", size: 650 },
+  status: { header: "Status", size: 120 },
   created_at: { header: "Created", cell: DataTable.cellRender.date, size: 166 },
 }
 
@@ -32,10 +32,10 @@ function component() {
   const menu = [
     {
       title: "Delete", action: async (v) => {
-        await supabase.from("models").delete().eq("id", v.id)
+        await supabase.from("teams").delete().eq("id", v.id)
       },
       icon: <Trash2 />,
-      ask: "Are you sure you want to delete this model?",
+      ask: "Are you sure you want to delete this team?",
     },
   ] satisfies DropdownMenuContents
 
@@ -46,14 +46,14 @@ function component() {
         <PageTitle />
         <div className="grow"></div>
         <div>
-          <Button className="rounded-lg" onClick={() => navigate('/settings/modelsd/new')}><Plus className="h-4 w-4" />New Model</Button>
+          <Button className="rounded-lg" onClick={() => navigate('/settings/teamsd/new')}><Plus className="h-4 w-4" />New Team</Button>
         </div>
       </div>
       <DataTableSupabase
-        table="models"
+        table="teams"
         columns={columns}
         hideSelection
-        onRowClick={"/settings/modelsd"}
+        onRowClick={"/settings/teamsd"}
         sort={["created_at", "desc"]}
         actions={menu}
       />
@@ -61,4 +61,3 @@ function component() {
   </Page>
 
 }
-

--- a/src/pages/dev/templates/index.tsx
+++ b/src/pages/dev/templates/index.tsx
@@ -1,5 +1,5 @@
 import { Page, PageTitle } from "@/components/page"
-import { BrainIcon, Plus, Sparkles } from "lucide-react"
+import { Book, BrainIcon, Plus, Sparkles } from "lucide-react"
 import { DataTableSupabase } from "@/components/datatable/supadatatable"
 import { DataTable } from "@/components/datatable/datatable"
 import { useTeamStore } from "@/lib/hooks/useTeam"
@@ -7,22 +7,22 @@ import { Button } from "@/components/ui/button"
 import { useNavigate } from "react-router-dom"
 import { DeclarativeMenu } from "@/components/declarativemenu"
 
-export const agents = {
-  title: "Agents",
-  description: "Manage your agents and their configurations.",
-  route: "/agents",
-  url: "/agents",
-  icon: BrainIcon,
+export const templates = {
+  title: "Templates 🧪",
+  description: "Manage your organization's templates.",
+  route: "/templatesd",
+  url: "/templatesd",
+  icon: Book,
   component,
-  resource: "agents",
+  resource: "templates",
   action: "read",
 } satisfies PageConfig
 
 const columns: Columns<Table<"agents">> = {
   id: { header: "ID", cell: DataTable.cellRender.number, size: 64 },
   title: { header: "Title", size: 620 },
+  description: { header: "Description", size: 450 },
   created_at: { header: "Created", cell: DataTable.cellRender.date, size: 166 },
-  description: { header: "Description", size: 380 },
 }
 
 function component() {
@@ -32,8 +32,6 @@ function component() {
 
   const menu = [
     { title: "New Agent", action: () => navigate('/agent/new'), icon: <Plus /> },
-    { title: "From Template", action: () => console.log("From Template") },
-    { title: "Auto-Generate", action: () => console.log("Auto-Generate"), icon: <Sparkles /> },
   ] satisfies DropdownMenuContents
 
 
@@ -43,19 +41,16 @@ function component() {
         <PageTitle />
         <div className="grow"></div>
         <div>
-          <DeclarativeMenu menu={menu}>
-            <Button className="rounded-lg"><Plus className="h-4 w-4" />Create Agent</Button>
-          </DeclarativeMenu>
+          <Button className="rounded-lg" onClick={() => navigate('/settings/agent/new')}><Plus className="h-4 w-4" />New Agent</Button>
         </div>
       </div>
       <DataTableSupabase
         table="agents"
         hideSelection
-        hideActions
         columns={columns}
         onRowClick={"/agent"}
         sort={["created_at", "desc"]}
-        filter={q => q.eq("team_id", selectedTeam?.id)}
+        filter={q => q.is("team_id", null)}
       // select={`
       //   *,
       //   agent (

--- a/src/pages/dev/users/index.tsx
+++ b/src/pages/dev/users/index.tsx
@@ -3,26 +3,33 @@ import { DataTableSupabase } from "@/components/datatable/supadatatable"
 import { Page, PageTitle } from "@/components/page"
 import { Button } from "@/components/ui/button"
 import { supabase } from "@/lib/data"
-import { Box, Plus, Trash2 } from "lucide-react"
+import { Users, Plus, Trash2 } from "lucide-react"
 import { useNavigate } from "react-router-dom"
 
-export const models = {
-  title: "Models",
-  description: "Manage your organization's AI Models.",
-  route: "/settings/modelsd",
-  url: "/settings/modelsd",
-  icon: Box,
+export const users = {
+  title: "Users",
+  description: "Manage your organization's users.",
+  route: "/settings/usersd",
+  url: "/settings/usersd",
+  icon: Users,
   component,
   group: "settings",
-  resource: "models",
+  resource: "users",
   action: "read",
 } satisfies PageConfig
 
-const columns: Columns<Table<"models">> = {
-  title: { header: "Title", size: 600 },
-  model: { header: "Model", size: 340 },
-  provider: { header: "Provider", size: 120 },
+const columns: Columns<Table<"users">> = {
+  first_name: { header: "First Name", size: 200 },
+  last_name: { header: "Last Name", size: 200 },
+  email: { header: "Email", size: 300 },
+  status: { header: "Status", size: 120 },
   created_at: { header: "Created", cell: DataTable.cellRender.date, size: 166 },
+  role: { header: "Role", size: 120 },
+  team: { header: "Team", size: 200 },
+  // title: { header: "Title", size: 200 },
+  // description: { header: "Description", size: 400 },
+  // language: { header: "Language", size: 120 },
+  // location: { header: "Location", size: 120 },
 }
 
 function component() {
@@ -32,10 +39,10 @@ function component() {
   const menu = [
     {
       title: "Delete", action: async (v) => {
-        await supabase.from("models").delete().eq("id", v.id)
+        await supabase.from("users").delete().eq("id", v.id)
       },
       icon: <Trash2 />,
-      ask: "Are you sure you want to delete this model?",
+      ask: "Are you sure you want to delete this user?",
     },
   ] satisfies DropdownMenuContents
 
@@ -46,14 +53,14 @@ function component() {
         <PageTitle />
         <div className="grow"></div>
         <div>
-          <Button className="rounded-lg" onClick={() => navigate('/settings/modelsd/new')}><Plus className="h-4 w-4" />New Model</Button>
+          <Button className="rounded-lg" onClick={() => navigate('/settings/usersd/new')}><Plus className="h-4 w-4" />New User</Button>
         </div>
       </div>
       <DataTableSupabase
-        table="models"
+        table="users"
         columns={columns}
         hideSelection
-        onRowClick={"/settings/modelsd"}
+        onRowClick={"/settings/usersd"}
         sort={["created_at", "desc"]}
         actions={menu}
       />
@@ -61,4 +68,3 @@ function component() {
   </Page>
 
 }
-


### PR DESCRIPTION
refactor: enhance PageTitle component to accept children and improve layout

chore: extend database types to include Views for better type safety

feat: reorganize pages structure and update imports for better clarity

delete: remove deprecated agents and logs pages

fix: adjust DataTable component usage in dtprops page

feat: implement CRUD functionality in models and templates pages

feat: add CRUDToolbar for consistent create/update/delete actions across pages

feat: create new agentlogs page for logging data management

feat: implement new pages for managing API keys, collections, projects, roles, sources, teams, templates, and users with CRUD operations